### PR TITLE
Fix different sortings of base content in header and data rows

### DIFF
--- a/bin/SeqFilter
+++ b/bin/SeqFilter
@@ -727,7 +727,7 @@ sub init{
     }
 
 
-    $opt{_base_content} = [split(/\s*,\s*/, $opt{base_content})] if $opt{base_content};
+    $opt{_base_content} = [sort split(/\s*,\s*/, $opt{base_content})] if $opt{base_content};
     $opt{_N} = [sort{$a <=> $b}(split(/\s*,\s*/, $opt{N}))] if $opt{N};
 
     # stat file handle


### PR DESCRIPTION
The fix just sort the requested base content in alphabetical order.
Therefore, while final output, the header and the data row have the same order.

Fix #7 